### PR TITLE
Make 'div->test' possible

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,5 +1,5 @@
 function parse(cv) {
-  part = cv.toString().split(" -> ")
+  part = cv.toString().split("->")
   tagname = part[0].replace(/\s/g,'')
   switch(tagname) {
     case "h1":


### PR DESCRIPTION
# Description

I just replace " -> " by "->".
Now, we can write :
```html
div 
	p-> test
end->div
```
