### PR TITLE
Fixed the type error

### DIFF
--- a/experimental/precompiler.c
+++ b/experimental/precompiler.c
@@ -194,7 +194,7 @@ const char * parse(char * gotten) {
             return concat4("<", array[0], array[1], " />");
         }
     } else {
-        //return array;
+        return (char*)*array;
     }
 }
 


### PR DESCRIPTION
Hello,

There was a bug :
```
precompiler.c:197:16: warning: incompatible pointer types returning 'char *[3]' from a function with result
      type 'const char *' [-Wincompatible-pointer-types]
        return array;
               ^~~~~
precompiler.c:197:16: warning: address of stack memory associated with local variable 'array' returned
      [-Wreturn-stack-address]
        return array;
```
I fixed it with replacing this line :
`return array;`
By this :
`return (char*)*array;`

PS: On my computer, the malloc lib doesn't work. I change `#include <malloc.h>` by  `#include <malloc/malloc.h>` to make it works but I didn't put it in the commit.